### PR TITLE
Added ability to suppress the next returned state from /system_status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
 Changelog for Mantarray Frontend Components
 ===========================================
+0.1.12 (2021-01-27)
+------------------
+
+ - Fixed issue where an immediately returned /system_status could change the state if a start/stop calibration/recording/liveview command was just sent
+
 0.1.11 (2021-01-15)
 ------------------
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@curi-bio/mantarray-frontend-components",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "shared components between web and desktop app.",
   "main": "./dist/mantarray.common.js",
   "author": "Curi Bio <contact@curibio.com> (http://www.curibio.com/)",

--- a/store/modules/flask/actions.js
+++ b/store/modules/flask/actions.js
@@ -51,7 +51,7 @@ export async function ping_system_status() {
             { root: true }
           );
         }
-        if (status_uuid == STATUS.MESSAGE.STOPPED_uuid) {
+        if (status_uuid == STATUS.MESSAGE.STOPPED) {
           this.dispatch(
             "playback/transition_playback_state",
             PLAYBACK_ENUMS.PLAYBACK_STATES.CALIBRATED,

--- a/store/modules/flask/actions.js
+++ b/store/modules/flask/actions.js
@@ -23,6 +23,7 @@ export async function ping_system_status() {
   if (result.status == 200) {
     const data = result.data;
     const status_uuid = data.ui_status_code;
+
     const simulation_mode = data.in_simulation_mode;
     if (this.state.barcode_manual_mode === false) {
       if (data.plate_barcode != undefined) {
@@ -37,41 +38,48 @@ export async function ping_system_status() {
       }
     }
     this.commit("set_simulation_status", simulation_mode);
-
-    if (status_uuid != this.state.status_uuid) {
-      this.commit("set_status_uuid", status_uuid);
-      if (status_uuid == STATUS.MESSAGE.CALIBRATION_NEEDED_uuid) {
-        this.dispatch(
-          "playback/transition_playback_state",
-          PLAYBACK_ENUMS.PLAYBACK_STATES.CALIBRATION_NEEDED,
-          { root: true }
-        );
-      }
-      if (status_uuid == STATUS.MESSAGE.STOPPED_uuid) {
-        this.dispatch(
-          "playback/transition_playback_state",
-          PLAYBACK_ENUMS.PLAYBACK_STATES.CALIBRATED,
-          { root: true }
-        );
-      }
-
-      if (status_uuid == STATUS.MESSAGE.LIVE_VIEW_ACTIVE_uuid) {
-        if (
-          this.rootState.playback.playback_state ==
-          PLAYBACK_ENUMS.PLAYBACK_STATES.BUFFERING
-        ) {
-          this.dispatch("waveform/start_get_waveform_pinging", null, {
-            root: true,
-          });
+    if (
+      this.state.ignore_next_system_status_if_matching_this_status !==
+      status_uuid
+    ) {
+      if (status_uuid != this.state.status_uuid) {
+        this.commit("set_status_uuid", status_uuid);
+        if (status_uuid == STATUS.MESSAGE.CALIBRATION_NEEDED_uuid) {
+          this.dispatch(
+            "playback/transition_playback_state",
+            PLAYBACK_ENUMS.PLAYBACK_STATES.CALIBRATION_NEEDED,
+            { root: true }
+          );
         }
-        this.dispatch(
-          "playback/transition_playback_state",
-          PLAYBACK_ENUMS.PLAYBACK_STATES.LIVE_VIEW_ACTIVE,
-          { root: true }
-        );
+        if (status_uuid == STATUS.MESSAGE.STOPPED_uuid) {
+          this.dispatch(
+            "playback/transition_playback_state",
+            PLAYBACK_ENUMS.PLAYBACK_STATES.CALIBRATED,
+            { root: true }
+          );
+        }
+
+        if (status_uuid == STATUS.MESSAGE.LIVE_VIEW_ACTIVE_uuid) {
+          if (
+            this.rootState.playback.playback_state ==
+            PLAYBACK_ENUMS.PLAYBACK_STATES.BUFFERING
+          ) {
+            this.dispatch("waveform/start_get_waveform_pinging", null, {
+              root: true,
+            });
+          }
+          this.dispatch(
+            "playback/transition_playback_state",
+            PLAYBACK_ENUMS.PLAYBACK_STATES.LIVE_VIEW_ACTIVE,
+            { root: true }
+          );
+        }
       }
     }
   }
+  this.commit("flask/ignore_next_system_status_if_matching_status", null, {
+    root: true,
+  }); // reset back to NULL now that a full call to /system_status has been processed
 }
 
 export default {

--- a/store/modules/flask/enums.js
+++ b/store/modules/flask/enums.js
@@ -9,7 +9,7 @@ export const STATUS = {
     CALIBRATION_NEEDED: "009301eb-625c-4dc4-9e92-1a4d0762465f",
     CALIBRATING_uuid: "43c08fc5-ca2f-4dcd-9dff-5e9324cb5dbf",
     CALIBRATING: "43c08fc5-ca2f-4dcd-9dff-5e9324cb5dbf",
-    STOPPED_uuid: "b480373b-9466-4fa0-92a6-fa5f8e340d30",
+    STOPPED: "b480373b-9466-4fa0-92a6-fa5f8e340d30",
     CALIBRATED: "b480373b-9466-4fa0-92a6-fa5f8e340d30",
     BUFFERING_uuid: "dc774d4b-6bd1-4717-b36e-6df6f1ef6cf4",
     BUFFERING: "dc774d4b-6bd1-4717-b36e-6df6f1ef6cf4",

--- a/store/modules/flask/index.js
+++ b/store/modules/flask/index.js
@@ -11,6 +11,7 @@ const default_state = {
   status_uuid: STATUS.MESSAGE.SERVER_STILL_INITIALIZING,
   simulation_mode: false,
   barcode_manual_mode: false,
+  ignore_next_system_status_if_matching_this_status: null,
 };
 
 // adapted from https://itnext.io/eating-my-advice-efficiently-improving-on-understanding-and-using-nuxt-vuex-6d00769014a2

--- a/store/modules/flask/mutations.js
+++ b/store/modules/flask/mutations.js
@@ -25,4 +25,7 @@ export default {
   set_barcode_manual_mode(state, new_value) {
     state.barcode_manual_mode = new_value;
   },
+  ignore_next_system_status_if_matching_status(state, new_status) {
+    state.ignore_next_system_status_if_matching_this_status = new_status;
+  },
 };

--- a/store/modules/playback/actions.js
+++ b/store/modules/playback/actions.js
@@ -121,6 +121,11 @@ export default {
       ENUMS.PLAYBACK_STATES.CALIBRATED
     );
     context.commit("set_x_time_index", 0);
+    context.commit(
+      "flask/ignore_next_system_status_if_matching_status",
+      STATUS.MESSAGE.LIVE_VIEW_ACTIVE,
+      { root: true }
+    );
     context.commit("flask/set_status_uuid", STATUS.MESSAGE.STOPPED, {
       root: true,
     });

--- a/store/modules/playback/actions.js
+++ b/store/modules/playback/actions.js
@@ -205,6 +205,11 @@ export default {
       "transition_playback_state",
       ENUMS.PLAYBACK_STATES.BUFFERING
     );
+    context.commit(
+      "flask/ignore_next_system_status_if_matching_status",
+      STATUS.MESSAGE.CALIBRATED,
+      { root: true }
+    );
     context.commit("flask/set_status_uuid", STATUS.MESSAGE.BUFFERING, {
       root: true,
     });

--- a/store/modules/playback/actions.js
+++ b/store/modules/playback/actions.js
@@ -59,7 +59,12 @@ export default {
       "transition_playback_state",
       ENUMS.PLAYBACK_STATES.RECORDING
     );
-    context.commit("flask/set_status_uuid", STATUS.MESSAGE.RECORDING_uuid, {
+    context.commit(
+      "flask/ignore_next_system_status_if_matching_status",
+      STATUS.MESSAGE.LIVE_VIEW_ACTIVE,
+      { root: true }
+    );
+    context.commit("flask/set_status_uuid", STATUS.MESSAGE.RECORDING, {
       root: true,
     });
 
@@ -115,7 +120,7 @@ export default {
       ENUMS.PLAYBACK_STATES.CALIBRATED
     );
     context.commit("set_x_time_index", 0);
-    context.commit("flask/set_status_uuid", STATUS.MESSAGE.STOPPED_uuid, {
+    context.commit("flask/set_status_uuid", STATUS.MESSAGE.STOPPED, {
       root: true,
     });
     context.commit("stop_playback_progression");

--- a/store/modules/playback/actions.js
+++ b/store/modules/playback/actions.js
@@ -146,6 +146,12 @@ export default {
       endpoint: "start_calibration",
     };
     await this.dispatch("playback/start_stop_axios_request", payload);
+    context.commit(
+      "flask/ignore_next_system_status_if_matching_status",
+      this.state.flask.status_uuid,
+      { root: true }
+    );
+
     context.commit("flask/set_status_uuid", STATUS.MESSAGE.CALIBRATING, {
       root: true,
     });

--- a/store/modules/playback/actions.js
+++ b/store/modules/playback/actions.js
@@ -92,12 +92,13 @@ export default {
     );
     context.commit("stop_recording");
     context.commit(
-      "flask/set_status_uuid",
-      STATUS.MESSAGE.LIVE_VIEW_ACTIVE_uuid,
-      {
-        root: true,
-      }
+      "flask/ignore_next_system_status_if_matching_status",
+      STATUS.MESSAGE.RECORDING,
+      { root: true }
     );
+    context.commit("flask/set_status_uuid", STATUS.MESSAGE.LIVE_VIEW_ACTIVE, {
+      root: true,
+    });
     // Eli (6/11/20): wait until we have error handling established and unit tested before conditionally doing things based on status
     // if (response.status == 200) {
     //   context.commit(

--- a/tests/e2e/playback/controls/player/desktop-player.e2e.js
+++ b/tests/e2e/playback/controls/player/desktop-player.e2e.js
@@ -42,7 +42,7 @@ const mocked_system_status_static_calibration_needed = RequestMock()
 
 const mocked_static_system_status_states = RequestMock()
   .onRequestTo(system_status_when_calibrated_regexp)
-  .respond({ ui_status_code: STATUS.MESSAGE.STOPPED_uuid }, 200, {
+  .respond({ ui_status_code: STATUS.MESSAGE.STOPPED }, 200, {
     "Access-Control-Allow-Origin": "*",
   })
   .onRequestTo(system_status_when_calibration_needed_regexp)
@@ -76,7 +76,7 @@ const mocked_system_status_keep_calibrating = RequestMock()
 
 const mocked_system_status_finish_calibration = RequestMock()
   .onRequestTo(system_status_when_calibrating_regexp)
-  .respond({ ui_status_code: STATUS.MESSAGE.STOPPED_uuid }, 200, {
+  .respond({ ui_status_code: STATUS.MESSAGE.STOPPED }, 200, {
     "Access-Control-Allow-Origin": "*",
   });
 

--- a/tests/unit/components/playback/controls/DesktopPlayerControls.spec.js
+++ b/tests/unit/components/playback/controls/DesktopPlayerControls.spec.js
@@ -169,26 +169,26 @@ describe("DesktopPlayerControls.vue", () => {
 
         mocked_axios
           .onGet(system_status_when_calibrating_regexp)
-          .replyOnce(200, { ui_status_code: STATUS.MESSAGE.CALIBRATING_uuid });
+          .replyOnce(200, { ui_status_code: STATUS.MESSAGE.CALIBRATING });
         mocked_axios
           .onGet(system_status_when_calibrating_regexp)
-          .reply(200, { ui_status_code: STATUS.MESSAGE.STOPPED_uuid });
+          .reply(200, { ui_status_code: STATUS.MESSAGE.STOPPED });
 
         mocked_axios
           .onGet(system_status_when_recording_regexp)
-          .reply(200, { ui_status_code: STATUS.MESSAGE.RECORDING_uuid });
+          .reply(200, { ui_status_code: STATUS.MESSAGE.RECORDING });
 
         mocked_axios
           .onGet(system_status_when_live_view_active_regexp)
-          .reply(200, { ui_status_code: STATUS.MESSAGE.LIVE_VIEW_ACTIVE_uuid });
+          .reply(200, { ui_status_code: STATUS.MESSAGE.LIVE_VIEW_ACTIVE });
 
         mocked_axios
           .onGet(system_status_when_calibrated_regexp)
-          .reply(200, { ui_status_code: STATUS.MESSAGE.STOPPED_uuid });
+          .reply(200, { ui_status_code: STATUS.MESSAGE.STOPPED });
 
         mocked_axios
           .onGet(system_status_when_buffering_regexp)
-          .replyOnce(200, { ui_status_code: STATUS.MESSAGE.BUFFERING_uuid });
+          .replyOnce(200, { ui_status_code: STATUS.MESSAGE.BUFFERING });
         mocked_axios
           .onGet(system_status_when_buffering_regexp)
           .reply(200, { ui_status_code: STATUS.MESSAGE.LIVE_VIEW_ACTIVE_uuid });

--- a/tests/unit/store/flask.spec.js
+++ b/tests/unit/store/flask.spec.js
@@ -187,7 +187,7 @@ describe("store/flask", () => {
       );
 
       expect(store.state.flask.status_uuid).toStrictEqual(
-        STATUS.MESSAGE.STOPPED_uuid
+        STATUS.MESSAGE.STOPPED
       );
       expect(store.state.playback.playback_state).toStrictEqual(
         playback_module.ENUMS.PLAYBACK_STATES.CALIBRATED

--- a/tests/unit/store/flask.spec.js
+++ b/tests/unit/store/flask.spec.js
@@ -27,6 +27,8 @@ import {
   all_mantarray_commands_regexp as dist_all_mantarray_commands_regexp,
 } from "@/dist/mantarray.common";
 
+const valid_plate_barcode = "MB190440991";
+
 describe("store/flask", () => {
   const localVue = createLocalVue();
   localVue.use(Vuex);
@@ -191,6 +193,48 @@ describe("store/flask", () => {
         playback_module.ENUMS.PLAYBACK_STATES.CALIBRATED
       );
     });
+    describe("Given /system_status is mocked to return CALIBRATED as the status anda valid place barcode, and the current status is LIVE_VIEW_ACTIVE", () => {
+      beforeEach(() => {
+        mocked_axios.onGet(system_status_regexp).reply(200, {
+          ui_status_code: STATUS.MESSAGE.CALIBRATED,
+          in_simulation_mode: false,
+          plate_barcode: valid_plate_barcode,
+        });
+
+        store.commit("flask/set_status_uuid", STATUS.MESSAGE.LIVE_VIEW_ACTIVE);
+      });
+      test("Given the ignore_next_system_status_if_matching_this_status state is not null, When ping_system_status is called, Then the ignore_next_system_status_if_matching_this_status state becomes null", async () => {
+        store.commit(
+          "flask/ignore_next_system_status_if_matching_status",
+          STATUS.MESSAGE.RECORDING
+        );
+
+        // confirm pre-condition
+        expect(
+          store.state.flask.ignore_next_system_status_if_matching_this_status
+        ).not.toBeNull();
+
+        await bound_ping_system_status();
+
+        expect(
+          store.state.flask.ignore_next_system_status_if_matching_this_status
+        ).toBeNull();
+      });
+      test("Given the ignore_next_system_status_if_matching_this_status state is set to CALIBRATED, When ping_system_status is called, Then the state stays as LIVE_VIEW_ACTIVE (no change) but the barcode does update in Vuex", async () => {
+        store.commit(
+          "flask/ignore_next_system_status_if_matching_status",
+          STATUS.MESSAGE.CALIBRATED
+        );
+
+        await bound_ping_system_status();
+
+        expect(store.state.flask.status_uuid).toStrictEqual(
+          STATUS.MESSAGE.LIVE_VIEW_ACTIVE
+        );
+        expect(store.state.playback.barcode).toStrictEqual(valid_plate_barcode);
+      });
+    });
+
     test("Given /system_status is mocked to return LIVE_VIEW_ACTIVE as the status and the current status is BUFFERING, When ping_system_status is called, Then the URL should include the current state UUID and the vuex status state should update to LIVE_VIEW_ACTIVE and the Vuex Playback State should update to LIVE_VIEW_ACTIVE", async () => {
       mocked_axios
         .onGet(system_status_regexp) // We pass in_simulation_mode true and validate default false is replaced
@@ -371,7 +415,7 @@ describe("store/flask", () => {
     });
     describe("SERVER_READY", () => {
       let context = null;
-      const valid_plate_barcode = "MB190440991";
+
       const invalid_plate_barcode = "MD20044099";
       beforeEach(async () => {
         context = await store.dispatch("flask/get_flask_action_context");

--- a/tests/unit/store/playback.spec.js
+++ b/tests/unit/store/playback.spec.js
@@ -401,12 +401,12 @@ describe("store/playback", () => {
         store.state.playback.playback_progression_interval_id
       ).toStrictEqual(expected_interval_id);
     });
-    test("When start_recording is invoked, Then the playback and status states mutate to recording", async () => {
+    test("Given all axios requests are mocked to return status 200 and a valid barcode is set in Vuex and a playback x time index has been set, When start_recording is invoked, Then the playback and status states mutate to recording and the start of recording time is mutated to the x_time_index and an axios call was made to /start_recording with the correct time index and barcode and hardware_test_recording parameter and ignore_next_system_status_if_matching_this_status is mutated to LIVE_VIEW_ACTIVE", async () => {
       const api = "start_recording";
 
       mocked_axios.onGet(all_mantarray_commands_regexp).reply(200);
 
-      const expected_status_state = STATUS.MESSAGE.RECORDING_uuid;
+      const expected_status_state = STATUS.MESSAGE.RECORDING;
 
       // confirm pre-condition
       expect(store.state.playback.playback_state).not.toStrictEqual(
@@ -433,12 +433,16 @@ describe("store/playback", () => {
         expected_status_state
       );
       expect(store.state.playback.recording_start_time).toStrictEqual(12345);
+
+      expect(
+        store.state.flask.ignore_next_system_status_if_matching_this_status
+      ).toStrictEqual(STATUS.MESSAGE.LIVE_VIEW_ACTIVE);
     });
     test("When stop_recording is invoked, Then the playback and status states mutate to live_view_active", async () => {
       const api = "stop_recording";
 
       mocked_axios.onGet(all_mantarray_commands_regexp).reply(200);
-      const expected_status_state = STATUS.MESSAGE.LIVE_VIEW_ACTIVE_uuid;
+      const expected_status_state = STATUS.MESSAGE.LIVE_VIEW_ACTIVE;
       // confirm pre-condition
       expect(store.state.playback.playback_state).not.toStrictEqual(
         playback_module.ENUMS.PLAYBACK_STATES.LIVE_VIEW_ACTIVE
@@ -549,7 +553,7 @@ describe("store/playback", () => {
 
       mocked_axios.onGet(all_mantarray_commands_regexp).reply(200);
 
-      const expected_status_state = STATUS.MESSAGE.STOPPED_uuid;
+      const expected_status_state = STATUS.MESSAGE.STOPPED;
       store.commit("playback/set_x_time_index", 400);
       // confirm pre-condition
       expect(store.state.playback.playback_state).not.toStrictEqual(
@@ -580,7 +584,7 @@ describe("store/playback", () => {
 
       mocked_axios
         .onGet(system_status_when_calibrating_regexp)
-        .reply(200, { ui_status_code: STATUS.MESSAGE.STOPPED_uuid });
+        .reply(200, { ui_status_code: STATUS.MESSAGE.STOPPED });
 
       mocked_axios.onGet(all_mantarray_commands_regexp).reply(200);
 
@@ -614,7 +618,7 @@ describe("store/playback", () => {
 
       mocked_axios
         .onGet(system_status_when_buffering_regexp)
-        .reply(200, { ui_status_code: STATUS.MESSAGE.LIVE_VIEW_ACTIVE_uuid })
+        .reply(200, { ui_status_code: STATUS.MESSAGE.LIVE_VIEW_ACTIVE })
         .onGet(get_available_data_regex)
         .reply(204);
 

--- a/tests/unit/store/playback.spec.js
+++ b/tests/unit/store/playback.spec.js
@@ -596,26 +596,25 @@ describe("store/playback", () => {
 
         mocked_axios.onGet(all_mantarray_commands_regexp).reply(200);
       });
-      test("Given the flask status is set to CALIBRATION_NEEDED, When start_calibration is called, Then and ignore_next_system_status_if_matching_this_status is mutated to CALIBRATION_NEEDED", async () => {
-        const expected_state = STATUS.MESSAGE.CALIBRATION_NEEDED;
-        store.commit("flask/set_status_uuid", expected_state);
-        // confirm pre-condition
-        expect(store.state.flask.status_uuid).toStrictEqual(expected_state);
-        await store.dispatch("playback/start_calibration");
-        expect(
-          store.state.flask.ignore_next_system_status_if_matching_this_status
-        ).toStrictEqual(expected_state);
-      });
-      test("Given the flask status is set to CALIBRATED, When start_calibration is called, Then and ignore_next_system_status_if_matching_this_status is mutated to CALIBRATED", async () => {
-        const expected_state = STATUS.MESSAGE.CALIBRATED;
-        store.commit("flask/set_status_uuid", expected_state);
-        // confirm pre-condition
-        expect(store.state.flask.status_uuid).toStrictEqual(expected_state);
-        await store.dispatch("playback/start_calibration");
-        expect(
-          store.state.flask.ignore_next_system_status_if_matching_this_status
-        ).toStrictEqual(expected_state);
-      });
+      test.each([
+        ["CALIBRATION_NEEDED", "CALIBRATION_NEEDED"],
+        ["CALIBRATED", "CALIBRATED"],
+      ])(
+        "Given the flask status is set to %s, When start_calibration is called, Then ignore_next_system_status_if_matching_this_status is mutated to %s",
+        async (
+          expected_state_str,
+          copy_of_expected_state_for_test_title_display
+        ) => {
+          const expected_state = STATUS.MESSAGE[expected_state_str];
+          store.commit("flask/set_status_uuid", expected_state);
+          // confirm pre-condition
+          expect(store.state.flask.status_uuid).toStrictEqual(expected_state);
+          await store.dispatch("playback/start_calibration");
+          expect(
+            store.state.flask.ignore_next_system_status_if_matching_this_status
+          ).toStrictEqual(expected_state);
+        }
+      );
 
       test("When start_calibration is called, Then playback state mutates to calibrating and starts status_pinging in Flask, then playback state mutates to calibrated", async () => {
         // confirm pre-condition

--- a/tests/unit/store/playback.spec.js
+++ b/tests/unit/store/playback.spec.js
@@ -485,7 +485,7 @@ describe("store/playback", () => {
         await store.dispatch("waveform/start_get_waveform_pinging");
       });
 
-      test("When stop_live_view is dispatched, Then the clearInterval is called on the waveform_ping_interval_id", async () => {
+      test("When stop_live_view is dispatched, Then the clearInterval is called on the waveform_ping_interval_id and ignore_next_system_status_if_matching_this_status is set to LIVE_VIEW_ACTIVE", async () => {
         const spied_clear_interval = jest.spyOn(window, "clearInterval");
         const expected_interval_id =
           store.state.waveform.waveform_ping_interval_id;
@@ -494,6 +494,9 @@ describe("store/playback", () => {
 
         expect(spied_clear_interval).toHaveBeenCalledWith(expected_interval_id);
         expect(store.state.waveform.waveform_ping_interval_id).toBeNull();
+        expect(
+          store.state.flask.ignore_next_system_status_if_matching_this_status
+        ).toStrictEqual(STATUS.MESSAGE.LIVE_VIEW_ACTIVE);
       });
       test("Given the Vuex plate_waveforms state has some values, When stop_live_view is dispatched, Then the plate_waveforms x/y data points are reset to empty arrays", async () => {
         store.commit("waveform/set_plate_waveforms", [

--- a/tests/unit/store/playback.spec.js
+++ b/tests/unit/store/playback.spec.js
@@ -621,7 +621,7 @@ describe("store/playback", () => {
       });
     });
 
-    test("Given the /system_status is mocked with LIVE_VIEW_ACTIVE as response and /get_available_data as 204, When playback state mutates to BUFFERING and starts status_pinging in Flask, Then playback state mutates to LIVE_VIEW_ACTIVE", async () => {
+    test("Given the /system_status is mocked with LIVE_VIEW_ACTIVE as response and /get_available_data as 204, When playback state mutates to BUFFERING and starts status_pinging in Flask, Then playback state mutates to LIVE_VIEW_ACTIVE and ignore_next_system_status_if_matching_this_status mutates to CALIBRATED", async () => {
       const api = "start_managed_acquisition";
 
       mocked_axios
@@ -645,7 +645,9 @@ describe("store/playback", () => {
       expect(store.state.playback.playback_state).toStrictEqual(
         playback_module.ENUMS.PLAYBACK_STATES.BUFFERING
       );
-
+      expect(
+        store.state.flask.ignore_next_system_status_if_matching_this_status
+      ).toStrictEqual(STATUS.MESSAGE.CALIBRATED);
       await wait_for_expect(() => {
         expect(
           store.state.flask.status_ping_interval_id


### PR DESCRIPTION
Users reported sporadic issues where the software would sometimes revert back to "calibrated" after pressing "start live view".  It was determined from the logs that in rare cases a /system_status call could return saying the Mantarray itself was still in the "calibrated" state immediately after the /start_managed_acquisition route was called by the frontend, leading to inconsistencies between the state of the frontend and backend.

Solution for now is that the frontend can be instructed to ignore the next returned value from /system_status after dispatching a state change.  We should look into more robust solutions for the future