### PR TITLE
ESLint Computed Rule

### DIFF
--- a/components/playback/controls/StimulationStudioPlateWell.vue
+++ b/components/playback/controls/StimulationStudioPlateWell.vue
@@ -50,7 +50,14 @@ export default {
     strk: { type: String, default: "" },
     protocol_fill: { type: String, default: "" },
     stroke_wdth: { type: Number, default: 0 },
-    index: { type: Number, default: 0 },
+    index: {
+      type: Number,
+      default: 0,
+      validator: (value) => {
+        // Eli (2/5/21) The way this component currently computes the top/left positions requires that the index be within the valid range for a 24-well plate.
+        return value >= 0 && value < 24;
+      },
+    },
     protocol_type: { type: String, default: "" },
   },
   computed: {
@@ -67,6 +74,8 @@ export default {
                              as a result in the renderer the execution improves to a great extent
 
       */
+    // Eli (2/5/21): The prop validator for ``index`` ensures that the value will always be between 0-23
+    // eslint-disable-next-line vue/return-in-computed-property
     computed_top: function () {
       switch (this.index) {
         case 0:
@@ -98,8 +107,9 @@ export default {
         case 23:
           return 205.157;
       }
-      return 0;
     },
+    // Eli (2/5/21): The prop validator for ``index`` ensures that the value will always be between 0-23
+    // eslint-disable-next-line vue/return-in-computed-property
     computed_left: function () {
       switch (this.index) {
         case 0:
@@ -133,8 +143,9 @@ export default {
         case 23:
           return 339;
       }
-      return 0;
     },
+    // Eli (2/5/21): The prop validator for ``index`` ensures that the value will always be between 0-23
+    // eslint-disable-next-line vue/return-in-computed-property
     computed_protocol_top: function () {
       switch (this.index) {
         case 0:
@@ -166,8 +177,9 @@ export default {
         case 23:
           return 222.73;
       }
-      return 0;
     },
+    // Eli (2/5/21): The prop validator for ``index`` ensures that the value will always be between 0-23
+    // eslint-disable-next-line vue/return-in-computed-property
     computed_protocol_left: function () {
       switch (this.index) {
         case 0:
@@ -201,7 +213,6 @@ export default {
         case 23:
           return 361.521;
       }
-      return 0;
     },
   },
 };
@@ -209,32 +220,26 @@ export default {
 <style>
 .div__simulationstudio-plate-well-location {
   pointer-events: all;
-  transform: rotate(0deg);
   position: absolute;
   width: 66px;
   height: 66px;
-  visibility: visible;
-  z-index: 9;
 }
 
 .span__simulationstudio-plate-well-protocol-location {
   pointer-events: all;
   line-height: 100%;
-  transform: rotate(0deg);
   overflow: hidden;
   position: absolute;
   width: 25px;
   height: 25px;
   padding: 5px;
-  visibility: visible;
   user-select: none;
   font-family: Muli;
   font-weight: bold;
   font-style: normal;
   text-decoration: none;
   font-size: 20px;
-  color: rgb(255, 255, 255);
+  color: #ffffff;
   text-align: center;
-  z-index: 101;
 }
 </style>

--- a/components/playback/controls/StimulationStudioWidget.vue
+++ b/components/playback/controls/StimulationStudioWidget.vue
@@ -147,7 +147,6 @@ export default {
   border: 0px none rgb(0, 0, 0);
   border-radius: 10px;
   box-shadow: rgba(0, 0, 0, 0.7) 0px 0px 10px 0px;
-  z-index: 7;
   pointer-events: all;
 }
 .div__simulationstudio-plus-icon-container {
@@ -159,7 +158,6 @@ export default {
   top: calc(97.5px - 94px);
   left: calc(743.5px - 737.5px);
   visibility: visible;
-  z-index: 96;
 }
 
 .span__simulationstudio-plus-icon {
@@ -198,7 +196,6 @@ export default {
   font-size: 17px;
   color: rgb(183, 183, 183);
   text-align: center;
-  z-index: 63;
 }
 
 .span__simulationstudio-column-two-label {
@@ -221,7 +218,6 @@ export default {
   font-size: 17px;
   color: rgb(183, 183, 183);
   text-align: center;
-  z-index: 65;
 }
 
 .span__simulationstudio-column-three-label {
@@ -244,7 +240,6 @@ export default {
   font-size: 17px;
   color: rgb(183, 183, 183);
   text-align: center;
-  z-index: 67;
 }
 
 .span__simulationstudio-column-four-label {
@@ -267,7 +262,6 @@ export default {
   font-size: 17px;
   color: rgb(183, 183, 183);
   text-align: center;
-  z-index: 69;
 }
 
 .span__simulationstudio-column-five-label {
@@ -290,7 +284,6 @@ export default {
   font-size: 17px;
   color: rgb(183, 183, 183);
   text-align: center;
-  z-index: 71;
 }
 
 .span__simulationstudio-column-six-label {
@@ -313,7 +306,6 @@ export default {
   font-size: 17px;
   color: rgb(183, 183, 183);
   text-align: center;
-  z-index: 73;
 }
 
 .span__simulationstudio-row-A-label {
@@ -336,7 +328,6 @@ export default {
   font-size: 17px;
   color: rgb(183, 183, 183);
   text-align: left;
-  z-index: 57;
 }
 
 .span__simulationstudio-row-B-label {
@@ -359,7 +350,6 @@ export default {
   font-size: 17px;
   color: rgb(183, 183, 183);
   text-align: left;
-  z-index: 55;
 }
 
 .span__simulationstudio-row-C-label {
@@ -382,7 +372,6 @@ export default {
   font-size: 17px;
   color: rgb(183, 183, 183);
   text-align: left;
-  z-index: 61;
 }
 
 .span__simulationstudio-row-D-label {
@@ -405,6 +394,5 @@ export default {
   font-size: 17px;
   color: rgb(183, 183, 183);
   text-align: left;
-  z-index: 59;
 }
 </style>

--- a/tests/unit/components/playback/controls/StimulationStudioPlateWell.spec.js
+++ b/tests/unit/components/playback/controls/StimulationStudioPlateWell.spec.js
@@ -57,25 +57,15 @@ describe("StimulationStudioPlateWell.vue", () => {
     expect(well_circle.attributes("fill")).toStrictEqual("'#19AC8A'");
     expect(well_circle.attributes("stroke")).toStrictEqual("'#FFFFFF'");
   });
-  test("Given that a protocol type is A is set index -1  and stroke_wdth = 4 as propsData, When the mounted successfully, Then validate that protocol Text A and color as provided is applied on the circle with white cirlce of 4px", async () => {
-    const propsData = {
-      classname: "'plate_0'",
-      protocol_type: "'A'",
-      svg_height: 72,
-      svg_width: 72,
-      circle_x: 36,
-      circle_y: 36,
-      radius: 28,
-      strk: "'#FFFFFF'",
-      protocol_fill: "'#19AC8A'",
-      stroke_wdth: 4,
-      index: -1,
-    };
-    wrapper = mount(StimulationStudioPlateWell, {
-      propsData,
-      localVue,
-    });
-    const well = wrapper.findAll("circle");
-    expect(well).toHaveLength(1);
-  });
+  test.each([
+    ["too small", -1],
+    ["too large", 24],
+  ])(
+    "When the index prop validator is called on a value that is %s (%s), Then it declares it invalid",
+    async (test_description, test_index) => {
+      // adapted from https://vueschool.io/articles/vuejs-tutorials/how-to-test-custom-prop-validators-in-vuejs/
+      const validator = StimulationStudioPlateWell.props.index.validator;
+      expect(validator(test_index)).toBe(false);
+    }
+  );
 });


### PR DESCRIPTION
ESLint rules are almost always something we want to follow, but there are cases where it may not be applicable to a specific situation.

When ESLint triggers a warning, the developer has the decision to determine if they should make a quick correction to their code because it would be better to follow the ESLint guidance, if this is a situation where the ESLint rule should not be applied and it should be disabled for this line of code (and an explanation provided as a comment), or whether the ESLint warning is revealing that the overall current implementation approach is suboptimal and a new approach should be considered.

The developer should not try to "trick" ESLint by introducing odd behavior into the code that doesn't relate to the purpose of the code. This reduces readability of the code. If a specific ESLint rule is not applicable to a particular situation, then that rule should just explicitly be disabled so that it is clear to someone reading the code what the code is doing, and the justification for disabling that ESLint rule.